### PR TITLE
Fix/handle holiday name change

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/magnet_data/holidays/models.py
+++ b/magnet_data/holidays/models.py
@@ -50,7 +50,7 @@ class Holiday(models.Model):
             date_string = holiday_data['date']
             date = datetime.datetime.strptime(date_string, '%Y-%m-%d').date()
             name = holiday_data['name']
-            cls.objects.get_or_create(
+            cls.objects.update_or_create(
                 date=date,
                 country_code=country_code,
                 defaults={
@@ -71,8 +71,10 @@ class Holiday(models.Model):
             date_string = holiday_data['date']
             date = datetime.datetime.strptime(date_string, '%Y-%m-%d').date()
             name = holiday_data['name']
-            cls.objects.get_or_create(
+            cls.objects.update_or_create(
                 date=date,
-                name=name,
-                country_code=country_code
+                country_code=country_code,
+                defaults={
+                    'name': name,
+                },
             )

--- a/magnet_data/holidays/models.py
+++ b/magnet_data/holidays/models.py
@@ -57,24 +57,3 @@ class Holiday(models.Model):
                     'name': name,
                 },
             )
-
-        year += 1
-
-        request = Request(
-            f'https://data.magnet.cl/api/v1/holidays/{country_code.lower()}/{year}/'
-        )
-
-        response = urlopen(request)
-        data = json.loads(response.read())
-
-        for holiday_data in data['objects']:
-            date_string = holiday_data['date']
-            date = datetime.datetime.strptime(date_string, '%Y-%m-%d').date()
-            name = holiday_data['name']
-            cls.objects.update_or_create(
-                date=date,
-                country_code=country_code,
-                defaults={
-                    'name': name,
-                },
-            )

--- a/magnet_data/magnet_data_client.py
+++ b/magnet_data/magnet_data_client.py
@@ -96,7 +96,7 @@ class Holidays(Countries):
 
         while business_days_count > 0:
             final_date += datetime.timedelta(days=step)
-            
+
             if last_updated_year != final_date.year:
                 last_updated_year = final_date.year
                 self.update(country_code, year=last_updated_year)
@@ -118,8 +118,9 @@ class Holidays(Countries):
             start_date -- date to start counting from
             end_date -- date where to stop counting
         """
-        self.update(country_code, start_date.year)
-        self.update(country_code, end_date.year)
+        for year in range(start_date.year, end_date.year):
+            self.update(country_code, year)
+
         days = 0
 
         holidays_dates = self.cls.objects.filter(

--- a/magnet_data/magnet_data_client.py
+++ b/magnet_data/magnet_data_client.py
@@ -121,7 +121,7 @@ class Holidays(Countries):
             start_date -- date to start counting from
             end_date -- date where to stop counting
         """
-        for year in range(start_date.year, end_date.year):
+        for year in range(start_date.year, end_date.year + 1):
             self.update(country_code, year)
 
         days = 0

--- a/magnet_data/magnet_data_client.py
+++ b/magnet_data/magnet_data_client.py
@@ -20,11 +20,14 @@ class Currencies(CurrencyAcronyms):
 
 class Holidays(Countries):
     def __init__(self):
-        self.last_updated = {}
         self.cls = apps.get_model(
             app_label='magnet_data',
             model_name='Holiday'
         )
+        self.reset_cache()
+
+    def reset_cache(self):
+        self.last_updated = {}
 
     def update(self, country_code: str, year):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-magnet-data"
-version = "1.2.2"
+version = "1.2.3"
 description = "An API client for data.magnet.cl"
 authors = ["Ignacio Munizaga <muni@magnet.cl>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [
 python = "^3.6.2"
 django = ">=2.2"
 
-[tool.poetry.dev-dependencies]
+[poetry.group.dev.dependencies]
 black = "^22.6.0"
 flake8 = "^3.9.2"
 ipdb = "^0.13.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "django-magnet-data"
+name = "django_magnet_data"
 version = "1.2.3"
 description = "An API client for data.magnet.cl"
 authors = ["Ignacio Munizaga <muni@magnet.cl>"]


### PR DESCRIPTION
fix: Handle name change on a holiday

When someone changes the name of a holiday in data.magnet.cl the model
looked for an exact match (using the new name) but nothing was found
since the database had the old name, and when a new object was created,
a integrity error raised since only the country-date pair is unique

Also: refactor: delete duplicated code that updated a year and then the next

There was code in magnet_data/holidays/models.py that updated a year and then the next year. This is unnecessary since all methods that search dates update all the years they need.

bump: verstion to 1.2.3