### PR TITLE
fix: handle when a holiday changes date

### DIFF
--- a/magnet_data/admin.py
+++ b/magnet_data/admin.py
@@ -1,7 +1,7 @@
 # django
 from django.contrib import admin
 
-from holidays.models import Holiday
+from .holidays.models import Holiday
 
 
 class HolidayAdmin(admin.ModelAdmin):

--- a/magnet_data/holidays/admin.py
+++ b/magnet_data/holidays/admin.py
@@ -7,5 +7,17 @@ from holidays.models import Holiday
 class HolidayAdmin(admin.ModelAdmin):
     list_display = ("name", "date", "country_code")
 
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def get_readonly_fields(self, request, obj=None):
+        return [field.name for field in self.model._meta.fields]
+
 
 admin.site.register(Holiday, HolidayAdmin)

--- a/magnet_data/holidays/models.py
+++ b/magnet_data/holidays/models.py
@@ -46,14 +46,22 @@ class Holiday(models.Model):
         response = urlopen(request)
         data = json.loads(response.read())
 
+        updated_ids = []
+
         for holiday_data in data['objects']:
             date_string = holiday_data['date']
             date = datetime.datetime.strptime(date_string, '%Y-%m-%d').date()
             name = holiday_data['name']
-            cls.objects.update_or_create(
+
+            updated_ids.append(cls.objects.update_or_create(
                 date=date,
                 country_code=country_code,
                 defaults={
                     'name': name,
                 },
-            )
+            )[0].id)
+
+        cls.objects.filter(
+            date__year=year,
+            country_code=country_code,
+        ).exclude(id__in=updated_ids).delete()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django_magnet_data"
-version = "1.2.3"
+version = "1.2.4"
 description = "An API client for data.magnet.cl"
 authors = ["Ignacio Munizaga <muni@magnet.cl>"]
 license = "MIT"


### PR DESCRIPTION
When a holiday changes date, the current client created a new holiday in the new date, and kept the old one. 

I create the new holiday object with the new date, and then delete all holidays that where not present in the API for a year in a country.

I included a test to validate that only the old date is deleted. 